### PR TITLE
Feature/custom lookup fields

### DIFF
--- a/sdetools/alm_integration/alm_plugin_base.py
+++ b/sdetools/alm_integration/alm_plugin_base.py
@@ -148,8 +148,8 @@ class AlmConnector(object):
         Verify that the configuration options are set properly
         """
 
-        #Note: This will consider space as empty due to strip
-        #We do this before checking if the config is non-empty later
+        # Note: This will consider space as empty due to strip
+        # We do this before checking if the config is non-empty later
         self.config.process_list_config('selected_tasks')
         for task in self.config['selected_tasks']:
             if not RE_TASK_IDS.match(task):
@@ -235,7 +235,14 @@ class AlmConnector(object):
         logger.info('*** AlmConnector initialized ***')
 
     def init_custom_fields(self):
+        """
+        Apply any project-level macro substitutions to the custom field and lookup configuration
 
+        Available macros are:
+         - $application - Name of the application
+         - $project - Name of the project
+         - $context - User-defined context
+        """
         mapping = {
             'application': self.config['sde_application'],
             'project': self.config['sde_project'],
@@ -248,7 +255,7 @@ class AlmConnector(object):
 
         for config_option in config_custom_fields:
 
-            for field, value in self.config[config_option].items():
+            for field, value in self.config[config_option].iteritems():
                 matches = re.findall('\$\{?([a-zA-Z_]+)\}?', value)
                 if not matches:
                     continue

--- a/sdetools/modules/sync_jira/jira_plugin.py
+++ b/sdetools/modules/sync_jira/jira_plugin.py
@@ -18,6 +18,7 @@ JIRA_DEFAULT_PRIORITY_MAP = {
 
 class JIRAConnector(AlmConnector):
     alm_name = 'JIRA'
+    feature_custom_lookup = True
     default_priority_map = JIRA_DEFAULT_PRIORITY_MAP
 
     def __init__(self, config, alm_plugin):

--- a/sdetools/modules/sync_jira/jira_rest.py
+++ b/sdetools/modules/sync_jira/jira_rest.py
@@ -179,7 +179,7 @@ class JIRARestAPI(RESTBase):
                                                                  '%20AND%20'.join(task_lookup))
             result = self.call_api(url)
         except APIError, error:
-            raise AlmException("Unable to get task %s from JIRA. %s" % (task_id, error))
+            raise AlmException("Unable to search for task %s in JIRA. %s" % (task_id, error))
 
         if not result['total']:
             # No result was found from query

--- a/sdetools/modules/sync_jira/jira_soap.py
+++ b/sdetools/modules/sync_jira/jira_soap.py
@@ -66,7 +66,7 @@ class JIRASoapAPI:
             stream = opener.open('%s://%s/%srpc/soap/jirasoapservice-v2?wsdl' %
                     (self.config['alm_method'], self.config['alm_server'], self._get_context_root()))
         except urllib2.URLError, err:
-            raise AlmException('Unable to reach JIRA service (Check URL). Reason: %s' % (err))
+            raise AlmException('Unable to reach JIRA service (Check URL). Reason: %s' % err)
         except http_req.InvalidCertificateException, err:
             raise AlmException('Unable to verify SSL certificate for host: %s' % (self.config['alm_server']))
 
@@ -135,7 +135,7 @@ class JIRASoapAPI:
             #No result was found from query
             return None
 
-        #We will use the first result from the query
+        # We will use the first result from the query
         jtask = issues[0]
 
         task_resolution = None
@@ -244,7 +244,7 @@ class JIRASoapAPI:
         return True
 
     def add_task(self, task, issue_type_id, project_version):
-        #Add task
+        # Add task
         selected_priority = None
         for priority in self.priorities:
             if priority['name'] == task['alm_priority']:

--- a/sdetools/sdelib/conf_mgr.py
+++ b/sdetools/sdelib/conf_mgr.py
@@ -11,7 +11,7 @@ import datetime
 import log_mgr
 logger = log_mgr.mods.add_mod(__name__)
 
-from sdetools.sdelib.commons import UsageError, json
+from sdetools.sdelib.commons import UsageError, Error, json
 
 __all__ = ['Config']
 
@@ -66,6 +66,7 @@ class Option(object):
     def __repr__(self):
         return '%s(**%s)' % (self.__class__.__name__, str(self))
 
+
 class ModuleOptions(dict):
     """
     Note: The first item in sub_cmds is the default.
@@ -101,6 +102,7 @@ class ModuleOptions(dict):
         for item in self:
             dup[item] = self[item]
         return dup
+
 
 class Config(object):
     """
@@ -449,18 +451,6 @@ class Config(object):
             self[key] = datetime.datetime.strptime(self[key], '%Y-%m-%d').date()
         except ValueError, err:
             raise UsageError('Unable to read date field %s. Reason: %s' % (key, str(err)))
-
-    def transform(self, key, mapping):
-        for field, value in self[key].iteritems():
-            if isinstance(value, list):
-                new_value = []
-                for list_item in value:
-                    new_value.append(Template(list_item).substitute(mapping).strip())
-                self[key][field] = new_value
-            elif isinstance(value, basestring):
-                self[key][field] = Template(value).substitute(mapping).strip()
-            else:
-                raise TypeError('Unsupported type, cannot transform value: %s' % value)
 
     def set_custom_cert_loc(self, cert_loc):
         if not os.path.isfile(cert_loc):


### PR DESCRIPTION
Support a new config `alm_custom_lookup_fields` which is a JSON dictionary. When searching for tasks inside JIRA 5/6 or Rally projects we will query using the provided key=>value pairs.

Jira is unique in that we support JSON lists of strings as a dictionary value. Rally only supports strings as dictionary values.

