### PR TITLE
Allow users to bulk search and replace text in project task notes

### DIFF
--- a/sdetools/modules/__init__.py
+++ b/sdetools/modules/__init__.py
@@ -21,4 +21,5 @@ __all__ = [
     'connect',
     'add_ssl_cert',
     'fetch_config',
+    'modify_notes',
 ]

--- a/sdetools/modules/modify_notes.py
+++ b/sdetools/modules/modify_notes.py
@@ -1,0 +1,50 @@
+import re
+
+from sdetools.sdelib.cmd import BaseCommand
+from sdetools.sdelib.commons import Error, UsageError
+from sdetools.sdelib.restclient import APIError
+from sdetools.sdelib.interactive_plugin import PlugInExperience
+from sdetools.alm_integration.alm_plugin_base import AlmConnector
+
+
+class Command(BaseCommand):
+    help = 'Search and replace text in task notes'
+    sde_plugin = None
+
+    def configure(self):
+        self.sde_plugin = PlugInExperience(self.config)
+
+        self.config.opts.add('search_string', "Search string to find in a task note")
+        self.config.opts.add('replace_string', "Replacement string")
+
+    def sde_connect(self):
+        if not self.sde_plugin:
+            raise Error('Requires initialization')
+        try:
+            self.sde_plugin.connect()
+        except APIError, err:
+            raise Error('Unable to connect to SD Elements. Please review URL, id,'
+                    ' and password in configuration file. Reason: %s' % (str(err)))
+
+    def handle(self):
+        if not self.config['search_string']:
+            raise UsageError('Missing value for search_string')
+        if not self.config['replace_string']:
+            raise UsageError('Missing value for replace_string')
+
+        self.sde_connect()
+        tasks = self.sde_plugin.get_task_list()
+        for task in tasks:
+            task_notes = self.sde_plugin.get_task_notes(AlmConnector._extract_task_id(task['id']))
+            if 'ide' in task_notes:
+                for note in task_notes['ide']:
+                    new_note_text = re.sub(self.config['search_string'], self.config['replace_string'], note['text'])
+                    if new_note_text != note['text']:
+                        self.sde_plugin.update_task_ide_note(note['id'], new_note_text)
+            if 'text' in task_notes:
+                for note in task_notes['text']:
+                    new_note_text = re.sub(self.config['search_string'], self.config['replace_string'], note['text'])
+                    if new_note_text != note['text']:
+                        self.sde_plugin.update_task_text_note(note['id'], new_note_text)
+
+        return True

--- a/sdetools/sdelib/interactive_plugin.py
+++ b/sdetools/sdelib/interactive_plugin.py
@@ -158,6 +158,14 @@ class PlugInExperience:
         return self.api.add_task_ide_note("%d-%s" % (self.prj_id, task_id), text, filename, status)
 
     @_verify_connect
+    def update_task_ide_note(self, note_id, text, status=None):
+        return self.api.update_task_ide_note(note_id, text, status)
+
+    @_verify_connect
+    def update_task_text_note(self, note_id, text):
+        return self.api.update_task_text_note(note_id, text)
+
+    @_verify_connect
     def get_task_notes(self, task_id, note_type=''):
         return self.api.get_task_notes("%d-%s" % (self.prj_id, task_id), note_type)
 

--- a/sdetools/sdelib/sdeapi.py
+++ b/sdetools/sdelib/sdeapi.py
@@ -106,6 +106,20 @@ class ExtAPI(restclient.RESTBase):
             'task': task}
         return self.call_api('tasknotes/ide', self.URLRequest.POST, args=note)
 
+    def update_task_ide_note(self, note_id, text, status=None):
+        note = {
+            'text': text,
+        }
+        if status:
+            note['status'] = status
+        return self.call_api('tasknotes/ide/%d' % note_id, self.URLRequest.PUT, args=note)
+
+    def update_task_text_note(self, note_id, text):
+        note = {
+            'text': text,
+        }
+        return self.call_api('tasknotes/text/%d' % note_id, self.URLRequest.PUT, args=note)
+
     def get_task_notes(self, task, note_type, options={}, **filters):
         end_point = 'tasknotes'
         if note_type not in ['', 'ide', 'text', 'analysis']:


### PR DESCRIPTION
This command was motivated first by a need to rewrite ALM ticket references if an ALM server name is changed. It is generic enough to be used for other purposes